### PR TITLE
Fix a typo in RuntimeErrorContainer footer info

### DIFF
--- a/packages/react-error-overlay/src/containers/RuntimeErrorContainer.js
+++ b/packages/react-error-overlay/src/containers/RuntimeErrorContainer.js
@@ -79,7 +79,7 @@ class RuntimeErrorContainer extends PureComponent<Props, State> {
         />
         <Footer
           line1="This screen is visible only in development. It will not appear if the app crashes in production."
-          line2="Open your browser’s developer console to further inspect this error.  Click the 'X' or hit ESC to dismiss this message."
+          line2="Open your browser's developer console to further inspect this error.  Click the 'X' or hit ESC to dismiss this message."
         />
       </ErrorOverlay>
     );


### PR DESCRIPTION
Fixed a typo in RuntimeErrorContainer footer info.